### PR TITLE
Drop @charset

### DIFF
--- a/sample/01-mangle/helper.js
+++ b/sample/01-mangle/helper.js
@@ -1,9 +1,9 @@
 const dictionary = [
         ":",         "{",         "}",         "_",         " ",         "-", "animation",         "0",         "%",         ";",
         "1",         "@", "keyframes",   "opacity",       "100", "transform",    "rotate",         "(",       "deg",         ")",
-        "s",    "linear",         ".",         "8",         "9",       "360",         "#",   "display",      "flex",        ".2",
- "duration", "iteration",     "count",  "infinite",    "timing",  "function",      "name",         "3",         "4",         "5",
-        "6",        "6.",         "7",        "1.",         "2",
+        "s",    "linear",         ".",         "3",         "4",       "360",         "#",   "display",      "flex",        ".2",
+ "duration", "iteration",     "count",  "infinite",    "timing",  "function",      "name",         "8",         "9",        "1.",
+        "2",         "5",         "6",        "6.",         "7",
 ];
 const charToInteger = JSON.parse('{"0":52,"1":53,"2":54,"3":55,"4":56,"5":57,"6":58,"7":59,"8":60,"9":61,"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"a":26,"b":27,"c":28,"d":29,"e":30,"f":31,"g":32,"h":33,"i":34,"j":35,"k":36,"l":37,"m":38,"n":39,"o":40,"p":41,"q":42,"r":43,"s":44,"t":45,"u":46,"v":47,"w":48,"x":49,"y":50,"z":51,"+":62,"/":63,"=":64}');
 const decode = (encoded) => {
@@ -42,9 +42,6 @@ export const addStyle = (rules) => {
     }
     const cssStyleSheet = style.sheet;
     rules.forEach((words) => {
-        const rule = decode(words);
-        if (!(/^\s*@charset/i).test(rule)) {
-            cssStyleSheet.insertRule(rule, cssStyleSheet.cssRules.length);
-        }
+        cssStyleSheet.insertRule(decode(words), cssStyleSheet.cssRules.length);
     });
 };

--- a/sample/01-mangle/style1.css.js
+++ b/sample/01-mangle/style1.css.js
@@ -1,5 +1,5 @@
 import {addStyle} from './helper.js';
-addStyle(["WYIGqCCOQCaAOEcQCaAUEE","WYIGsCCOQCeAgBiBIIOkBmBEcQCeAgBiByBkBmBEE","0BGOC2BA4BSMA6BoBIqBIGqCE","sBGUCMK8BAUoBSMK+BKgCAiCSMKkCKmCAqBE","sBG2CG4CCMKoCAGsCE"]);
+addStyle(["WYIGuBCOQCaAOEcQCaAUEE","WYIGwBCOQCeAgBiBIIOkBmBEcQCeAgBiByBkBmBEE","0BGOC2BA4BSMA6BoBIqBIGuBE","sBGUCMK8BAUoBSMK+BKgCAiCSMKkCKmCAqBE","sBGuCGwCCMKoCAGwBE"]);
 export const className = {
     "icon": "_1",
     "rotate": "_2"

--- a/sample/01-mangle/style2.css.js
+++ b/sample/01-mangle/style2.css.js
@@ -1,5 +1,5 @@
 import {addStyle} from './helper.js';
-addStyle(["WYIGuBCOQCaAOEcQCaAUEE","WYIGwBCOQCeAgBiBIIOkBmBEcQCeAgBiByBkBmBEE","0BGuCC2BA4BSMA6BoBIqBIGuBE","sBGwCCMK8BAUoBSMK+BKgCAiCSMKkCKmCAqBE","sBGyCG0CCMKoCAGwBE"]);
+addStyle(["WYIGqCCOQCaAOEcQCaAUEE","WYIGsCCOQCeAgBiBIIOkBmBEcQCeAgBiByBkBmBEE","0BGyCC2BA4BSMA6BoBIqBIGqCE","sBG0CCMK8BAUoBSMK+BKgCAiCSMKkCKmCAqBE","sBG2CG4CCMKoCAGsCE"]);
 export const className = {
     "icon": "_6",
     "rotate": "_7"

--- a/sample/02-no-mangle/helper.js
+++ b/sample/02-no-mangle/helper.js
@@ -1,9 +1,9 @@
 const dictionary = [
         ":",         "{",         "}",         "_",         " ",         "-", "animation",         "0",         "%",    "rotate",
         ";",         "1",         "@", "keyframes",    "FadeIn",   "opacity",       "100",    "Rotate", "transform",         "(",
-      "deg",         ")",         "s",    "linear",         ".",      "icon",         "3",         "4",       "360",         "#",
+      "deg",         ")",         "s",    "linear",         ".",      "icon",         "8",         "9",       "360",         "#",
 "container",   "display",      "flex",        ".2",  "duration", "iteration",     "count",  "infinite",    "timing",  "function",
-     "name",         "8",         "9",        "1.",         "2",         "5",         "6",        "6.",         "7",
+     "name",         "3",         "4",         "5",         "6",        "6.",         "7",        "1.",         "2",
 ];
 const charToInteger = JSON.parse('{"0":52,"1":53,"2":54,"3":55,"4":56,"5":57,"6":58,"7":59,"8":60,"9":61,"A":0,"B":1,"C":2,"D":3,"E":4,"F":5,"G":6,"H":7,"I":8,"J":9,"K":10,"L":11,"M":12,"N":13,"O":14,"P":15,"Q":16,"R":17,"S":18,"T":19,"U":20,"V":21,"W":22,"X":23,"Y":24,"Z":25,"a":26,"b":27,"c":28,"d":29,"e":30,"f":31,"g":32,"h":33,"i":34,"j":35,"k":36,"l":37,"m":38,"n":39,"o":40,"p":41,"q":42,"r":43,"s":44,"t":45,"u":46,"v":47,"w":48,"x":49,"y":50,"z":51,"+":62,"/":63,"=":64}');
 const decode = (encoded) => {
@@ -42,9 +42,6 @@ export const addStyle = (rules) => {
     }
     const cssStyleSheet = style.sheet;
     rules.forEach((words) => {
-        const rule = decode(words);
-        if (!(/^\s*@charset/i).test(rule)) {
-            cssStyleSheet.insertRule(rule, cssStyleSheet.cssRules.length);
-        }
+        cssStyleSheet.insertRule(decode(words), cssStyleSheet.cssRules.length);
     });
 };

--- a/sample/02-no-mangle/style1.css.js
+++ b/sample/02-no-mangle/style1.css.js
@@ -1,5 +1,5 @@
 import {addStyle} from './helper.js';
-addStyle(["YaIcG0BCOQCeAOEgBQCeAWEE","YaIiBG2BCOQCkBASmBIIOoBqBEgBQCkBASmB4BoBqBEE","6B8BGOC+BAgCUMAiCsBIuBIcG0BE","wByBGWCMKkCAWsBUMKmCKoCAqCUMKsCKuCAuBE","wByBG2CSG4CCMKwCAiBG2BE"]);
+addStyle(["YaIcGyCCOQCeAOEgBQCeAWEE","YaIiBG0CCOQCkBASmBIIOoBqBEgBQCkBASmB4BoBqBEE","6B8BGOC+BAgCUMAiCsBIuBIcGyCE","wByBGWCMKkCAWsBUMKmCKoCAqCUMKsCKuCAuBE","wByBG+CSGgDCMKwCAiBG0CE"]);
 export const className = {
     "icon": "icon_1",
     "rotate": "rotate_2"

--- a/sample/02-no-mangle/style2.css.js
+++ b/sample/02-no-mangle/style2.css.js
@@ -1,5 +1,5 @@
 import {addStyle} from './helper.js';
-addStyle(["YaIcGyCCOQCeAOEgBQCeAWEE","YaIiBG0CCOQCkBASmBIIOoBqBEgBQCkBASmB4BoBqBEE","6B8BG6CC+BAgCUMAiCsBIuBIcGyCE","wByBG8CCMKkCAWsBUMKmCKoCAqCUMKsCKuCAuBE","wByBG+CSGgDCMKwCAiBG0CE"]);
+addStyle(["YaIcG0BCOQCeAOEgBQCeAWEE","YaIiBG2BCOQCkBASmBIIOoBqBEgBQCkBASmB4BoBqBEE","6B8BG2CC+BAgCUMAiCsBIuBIcG0BE","wByBG4CCMKkCAWsBUMKmCKoCAqCUMKsCKuCAuBE","wByBG6CSG8CCMKwCAiBG2BE"]);
 export const className = {
     "icon": "icon_6",
     "rotate": "rotate_7"

--- a/src/helper/default.js
+++ b/src/helper/default.js
@@ -36,9 +36,6 @@ export const addStyle = (rules) => {
     }
     const cssStyleSheet = style.sheet;
     rules.forEach((words) => {
-        const rule = decode(words);
-        if (!(/^\s*@charset/i).test(rule)) {
-            cssStyleSheet.insertRule(rule, cssStyleSheet.cssRules.length);
-        }
+        cssStyleSheet.insertRule(decode(words), cssStyleSheet.cssRules.length);
     });
 };

--- a/src/helper/default.ts
+++ b/src/helper/default.ts
@@ -42,9 +42,6 @@ export const addStyle = (rules: Array<string | {$$esifycss: string}>): void => {
     }
     const cssStyleSheet = style.sheet as CSSStyleSheet;
     rules.forEach((words) => {
-        const rule = decode(words);
-        if (!(/^\s*@charset/i).test(rule)) {
-            cssStyleSheet.insertRule(rule, cssStyleSheet.cssRules.length);
-        }
+        cssStyleSheet.insertRule(decode(words), cssStyleSheet.cssRules.length);
     });
 };

--- a/src/minifier/minifyScriptsForCSS.ts
+++ b/src/minifier/minifyScriptsForCSS.ts
@@ -8,8 +8,7 @@ export const minifyScriptForCSS = async (
     const cssList: Array<string> = [];
     let code = data.script;
     for (let index = data.ranges.length; index--;) {
-        const range = data.ranges[index];
-        cssList[index] = range.css;
+        cssList[index] = data.ranges[index].css;
     }
     code = data.statements
     .sort((range1, range2) => range1.start < range2.start ? 1 : -1)

--- a/src/postcssPlugin/minify.ts
+++ b/src/postcssPlugin/minify.ts
@@ -10,7 +10,17 @@ export const minify = (
             node.remove();
             break;
         case 'atrule':
-            Object.assign(node.raws, {before: '', between: '', afterName: ' '});
+            if (node.name === 'charset') {
+                /**
+                 * https://www.w3.org/TR/CSS2/syndata.html#x57
+                 * > User agents must ignore any @charset rule not at the beginning of the style sheet.
+                 * https://www.w3.org/TR/css-syntax-3/#charset-rule
+                 * > However, there is no actual at-rule named @charset.
+                 */
+                node.remove();
+            } else {
+                Object.assign(node.raws, {before: '', between: '', afterName: ' '});
+            }
             break;
         case 'rule':
             node.selector = node.selector

--- a/src/runner/Session.css.test.ts
+++ b/src/runner/Session.css.test.ts
@@ -36,6 +36,7 @@ test('#css', async (t) => {
         {
             path: 'input2.css',
             content: [
+                '@charset "utf-8";',
                 '.a2 {color: a2}',
                 '.b2 {color: b2}',
             ],
@@ -65,9 +66,11 @@ test('#css', async (t) => {
         b2: '_3',
     });
     const resultCSS = await readFile(cssPath, 'utf8');
-    const {nodes = []} = postcss.parse(resultCSS);
-    t.truthy(nodes.find((node) => isRule(node) && node.selector === `.${result1.className.a1}`));
-    t.truthy(nodes.find((node) => isRule(node) && node.selector === `.${result1.className.b1}`));
-    t.truthy(nodes.find((node) => isRule(node) && node.selector === `.${result2.className.a2}`));
-    t.truthy(nodes.find((node) => isRule(node) && node.selector === `.${result2.className.b2}`));
+    t.log(`==== resultCSS ====\n${resultCSS}\n===================`);
+    const root = postcss.parse(resultCSS);
+    t.log(root.toJSON());
+    t.truthy(root.nodes.find((node) => isRule(node) && node.selector === `.${result1.className.a1}`));
+    t.truthy(root.nodes.find((node) => isRule(node) && node.selector === `.${result1.className.b1}`));
+    t.truthy(root.nodes.find((node) => isRule(node) && node.selector === `.${result2.className.a2}`));
+    t.truthy(root.nodes.find((node) => isRule(node) && node.selector === `.${result2.className.b2}`));
 });

--- a/src/runner/Session.css.test.ts
+++ b/src/runner/Session.css.test.ts
@@ -29,16 +29,16 @@ test('#css', async (t) => {
         {
             path: 'input1.css',
             content: [
-                '.a1 {color: a1}',
-                '.b1 {color: b1}',
+                '.a1 {color: a1; width: 10%}',
+                '.b1 {color: b1; width: 20%}',
             ],
         },
         {
             path: 'input2.css',
             content: [
                 '@charset "utf-8";',
-                '.a2 {color: a2}',
-                '.b2 {color: b2}',
+                '.a2 {color: a2; width: 30%}',
+                '.b2 {color: b2; width: 40%}',
             ],
         },
     ];

--- a/src/runner/Session.test.ts
+++ b/src/runner/Session.test.ts
@@ -55,22 +55,22 @@ interface ITest {
                     t.deepEqual(Object.keys(keyframes), ['foo', 'bar']);
                     const nodes = root.nodes || [];
                     t.is(nodes.length, 3);
-                    {
-                        const node = nodes[0] as postcss.AtRule;
-                        t.is(node.type, 'atrule');
-                        t.is(node.name, 'keyframes');
-                        t.is(node.params, keyframes.foo);
-                    }
-                    {
-                        const node = nodes[1] as postcss.AtRule;
-                        t.is(node.type, 'atrule');
-                        t.is(node.name, 'keyframes');
-                        t.is(node.params, keyframes.bar);
-                    }
+                    t.like(nodes[0], {
+                        type: 'atrule',
+                        name: 'keyframes',
+                        params: keyframes.foo,
+                    });
+                    t.like(nodes[1], {
+                        type: 'atrule',
+                        name: 'keyframes',
+                        params: keyframes.bar,
+                    });
                     {
                         const node = nodes[2] as postcss.Rule;
-                        t.is(node.type, 'rule');
-                        t.is(node.selector, `.${className.foo}#${id.bar}`);
+                        t.like(node, {
+                            type: 'rule',
+                            selector: `.${className.foo}#${id.bar}`,
+                        });
                         const declarations = (node.nodes || []) as Array<postcss.Declaration>;
                         t.is(declarations.length, 1);
                         t.is(declarations[0].prop, 'animation');

--- a/src/runner/Session.test.ts
+++ b/src/runner/Session.test.ts
@@ -74,6 +74,36 @@ interface ITest {
             {
                 path: '/components/style.css',
                 content: [
+                    '@charset "UTF-8";',
+                    '.foo {color: blue}',
+                ],
+                test: (t, {className, id, keyframes, root}) => {
+                    t.deepEqual(Object.keys(id), []);
+                    t.deepEqual(Object.keys(className), ['foo']);
+                    t.deepEqual(Object.keys(keyframes), []);
+                    const [ruleNode, anotherNode] = root.nodes as Array<postcss.Rule>;
+                    t.is(anotherNode, undefined);
+                    t.like(ruleNode, {
+                        type: 'rule',
+                        selector: `.${className.foo}`,
+                    });
+                    const [declaration, anotherDeclaration] = ruleNode.nodes;
+                    t.is(anotherDeclaration, undefined);
+                    t.like(declaration, {
+                        type: 'decl',
+                        prop: 'color',
+                        value: 'blue',
+                    });
+                },
+            },
+        ],
+    },
+    {
+        parameters: {},
+        files: [
+            {
+                path: '/components/style.css',
+                content: [
                     '@keyframes foo {0%{color: red}100%{color:green}}',
                     '@keyframes bar {0%{color: red}100%{color:green}}',
                     '.foo#bar {animation: 1s 0.5s linear infinite foo, 1s 0.5s ease 5 bar}',

--- a/src/runner/generateScript.ts
+++ b/src/runner/generateScript.ts
@@ -6,7 +6,7 @@ const getCSS = (
     node: postcss.ChildNode,
 ): string => {
     const css = node.toString();
-    return css;
+    return css.endsWith('}') ? css : `${css};`;
 };
 
 export const generateScript = (

--- a/src/runner/generateScript.ts
+++ b/src/runner/generateScript.ts
@@ -16,13 +16,10 @@ export const generateScript = (
         /** The main contents of the output script. */
         result: IEsifyCSSResult,
         /** The root node will be splitted into rules that can be passed to insertRule. */
-        root?: postcss.Root,
+        root: postcss.Root,
         cssKey: string,
     },
 ): string => {
-    if (!props.root) {
-        throw new Error(`No root: ${props.root}`);
-    }
     let helperPath = path.relative(path.dirname(props.output), props.helper);
     helperPath = helperPath.replace(/\.ts$/, '');
     if (!path.isAbsolute(helperPath)) {

--- a/src/runner/generateScript.ts
+++ b/src/runner/generateScript.ts
@@ -2,6 +2,13 @@ import * as path from 'path';
 import * as postcss from 'postcss';
 import {IEsifyCSSResult} from '../postcssPlugin/types';
 
+const getCSS = (
+    node: postcss.ChildNode,
+): string => {
+    const css = node.toString();
+    return css;
+};
+
 export const generateScript = (
     /**
      * Returns a (TypeScript-compatible) JavaScript code that exports className,
@@ -27,7 +34,7 @@ export const generateScript = (
     }
     return [
         `import {addStyle} from '${helperPath.split(path.sep).join('/')}';`,
-        `addStyle([${props.root.nodes.map((node) => `{${props.cssKey}: ${JSON.stringify(node.toString())}}`).join(',')}]);`,
+        `addStyle([${props.root.nodes.map((node) => `{${props.cssKey}: ${JSON.stringify(getCSS(node))}}`).join(',')}]);`,
         `export const className = ${JSON.stringify(props.result.className, null, 4)};`,
         `export const id = ${JSON.stringify(props.result.id, null, 4)};`,
         `export const keyframes = ${JSON.stringify(props.result.keyframes, null, 4)};`,


### PR DESCRIPTION
Related: #104

# Issue

When a source includes `@charset`:

```css
@charset "utf-8";
.foo {color: red}
```
 and run esifycss with the `--css` options, it outputs unexpected css:
```css
@charset "utf-8"
._0 {color: red}
```
There's no semicolon at the end of the first line. The lines are parsed  as a single at-rule:

> Reproduction: https://runkit.com/kei-ito/charset-without-trailing-semicolon
> ![runkit](https://user-images.githubusercontent.com/7359068/97660001-c31f2b00-1ab3-11eb-84b7-0bd388d6680c.png)

```css
/* approximately equivalent code */
@charset "utf-8"._0 {
  color: red
}
```

# Investigation

First, I added `@charset "utf-8";` to src/runner/Session.css.test.ts.

https://github.com/kei-ito/esifycss/blob/f4cd9ea80d0d8886228de248026b4e2897d0b5d8/src/runner/Session.css.test.ts#L36-L43

The change got the error:

> https://github.com/kei-ito/esifycss/runs/1330032733?check_suite_focus=true#step:6:221
> ![ci-failure](https://user-images.githubusercontent.com/7359068/97666264-96bddb80-1ac0-11eb-9acd-37a40eebbe8e.png)

The error was from a css code generated by minifyScriptForCSS:

https://github.com/kei-ito/esifycss/blob/f4cd9ea80d0d8886228de248026b4e2897d0b5d8/src/minifier/minifyScriptsForCSS.ts#L5-L13

It makes an array of css codes↑ and concatenates them↓. 

https://github.com/kei-ito/esifycss/blob/f4cd9ea80d0d8886228de248026b4e2897d0b5d8/src/minifier/minifyScriptsForCSS.ts#L18-L19

The `range.css` is from `node.toString()` in src/runner/generateScript.ts.

https://github.com/kei-ito/esifycss/blob/f4cd9ea80d0d8886228de248026b4e2897d0b5d8/src/runner/generateScript.ts#L30

But the `node.toString()` doesn't serialize the trailing semicolon:

> Reproduction: https://runkit.com/kei-ito/charset-node
> ![node-to-string](https://user-images.githubusercontent.com/7359068/97667738-e520a980-1ac3-11eb-9065-8a6d5667880d.png)

# Fix

The goal is to make generateScript serialize the trailing semicolon if needed.

> https://github.com/kei-ito/esifycss/pull/105/files#diff-0c6a9c6bb0419a37114fa47f53182e02878c8ccf045a7566b1a5b9a7f72e9568
> ![fix](https://user-images.githubusercontent.com/7359068/97669164-dab3df00-1ac6-11eb-9ab1-d50ef14eeb76.png)

# Drop `@charset`

> https://www.w3.org/TR/css-syntax-3/#charset-rule
> However, there is no actual at-rule named `@charset`. When a stylesheet is actually parsed, any occurrences of an `@charset` rule must be treated as an unrecognized rule, and thus dropped as invalid when the stylesheet is grammar-checked.

I changed the minifier to omit `@charset` as it's not defined by the spec.